### PR TITLE
added carapace-bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ epm:install <package name>
     * [github.com/zzamboni/elvish-completions/cd](https://github.com/zzamboni/elvish-completions/blob/master/cd.org): completion for `cd`
     * [github.com/zzamboni/elvish-completions/git](https://github.com/zzamboni/elvish-completions/blob/master/git.org): completion for `git`
     * [github.com/zzamboni/elvish-completions/vcsh](https://github.com/zzamboni/elvish-completions/blob/master/vcsh.org): completion for `vcsh`
+  * [rsteube/carapace-bin](https://github.com/rsteube/carapace-bin) completions for various commands
 
 ## Elvish Libraries
   * Package [github.com/muesli/elvish-libs](https://github.com/muesli/elvish-libs)


### PR DESCRIPTION
Added [carapace-bin](https://github.com/rsteube/carapace-bin) which contains completions i am using.
Not entirely without issues (e.g. non-posix style commands are quite a pain) but works pretty well for me so far and might be useful to others.

closes #18 