### PR TITLE
Add elvish-bash-completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ epm:install <package name>
     * [github.com/zzamboni/elvish-completions/git](https://github.com/zzamboni/elvish-completions/blob/master/git.org): completion for `git`
     * [github.com/zzamboni/elvish-completions/vcsh](https://github.com/zzamboni/elvish-completions/blob/master/vcsh.org): completion for `vcsh`
   * [rsteube/carapace-bin](https://github.com/rsteube/carapace-bin) completions for various commands (not an `epm` package)
+  * [aca/elvish-bash-completion](https://github.com/aca/elvish-bash-completion) to convert any bash completion to elvish.
 
 ## Elvish Libraries
   * Package [github.com/muesli/elvish-libs](https://github.com/muesli/elvish-libs)


### PR DESCRIPTION
Based on [ezh/elvish-bash-completion](https://github.com/ezh/elvish-bash-completion).
Fixed issues with different quoting rules, word breaks, and so on.
I think this might handle almost all completion. Definitely not fast, but useful enough at least for me.

https://github.com/aca/elvish-bash-completion#Usage
```
epm:install github.com/aca/elvish-bash-completion
use github.com/aca/elvish-bash-completion/bash-completer

set edit:completion:arg-completer[man] = (bash-completer:new "man")
set edit:completion:arg-completer[ip] = (bash-completer:new "ip")
set edit:completion:arg-completer[journalctl] = (bash-completer:new "journalctl")
set edit:completion:arg-completer[tcpdump] = (bash-completer:new "tcpdump")
set edit:completion:arg-completer[iptables] = (bash-completer:new "iptables")
set edit:completion:arg-completer[rg] = (bash-completer:new "rg")
...
```