### PR TITLE
Add Helix to Editor Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ A curated list of awesome Elvish packages, modules, and tools that support Elvis
 | [Sublime Text 3](https://www.sublimetext.com) | [elvish_syntax_for_sublime](https://github.com/href/elvish_syntax_for_sublime) |
 | [PyCharm](https://www.jetbrains.com/pycharm) | [elvish-lang-plugin](https://github.com/sblundy/elvish-lang-plugin) |
 | [Micro](https://github.com/zyedidia/micro) | [elvish-micro-syntax](https://github.com/kolbycrouch/elvish-micro-syntax) |
+| [Helix](https://github.com/helix-editor/helix) | Builtin support; [elvish](https://github.com/elves/elvish) as `elvish -lsp` |
 
 ## Terminal Integration
 


### PR DESCRIPTION
Helix has built in support of elvish, and it uses `elvish -lsp` as its LSP provider.
https://github.com/helix-editor/helix/blob/master/languages.toml#L1522