### PR TITLE
Add link to elvish.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,4 +101,4 @@ A curated list of awesome Elvish packages, modules, and tools that support Elvis
 | 📄 [darcy-shen/oh-my-elvish](https://github.com/darcy-shen/oh-my-elvish) | User-friendly, productive and cross-platform elvish configuration. |
 | 🛠 [x-cmd](https://www.x-cmd.com/) | x-cmd is a vast and interesting collection of tools guided by the Unix philosophy, with [support for Elvish](https://www.x-cmd.com/mod/elv). |
 | 🛠 [dorothy](https://github.com/bevry/dorothy) | Bring your dotfile commands to any shell. Sensible defaults and hundreds of commands preloaded. Supports Elvish on macOS, Linux, Windows. |
-
+| 🛠 [elvish.nix](https://github.com/tesujimath/elvish.nix) | Nix support for Elvish packages, a multi-user-friendly alternative to `epm`. |


### PR DESCRIPTION
An alternative way to manage Elvish packages,  motivated by Elvish scripts bundled with their packages for multi-user installation.